### PR TITLE
Add .gitignore with Python ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Byte-compiled / optimized / DLL files
+*.pyc
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Added .gitignore file with common Python patterns:
• Byte-compiled files (*.pyc, __pycache__)
• Virtual environments (.env, .venv, venv/)
• Distribution files (dist/, build/, *.egg-info)
• IDE and OS files

Agent: gentle-gecko